### PR TITLE
Updated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.0.RELEASE</version>
+		<version>2.0.1.RELEASE</version>
 		<relativePath />
 	</parent>
 
@@ -35,17 +35,15 @@
 			<dependency>
 				<groupId>com.giffing.bucket4j.spring.boot.starter</groupId>
 				<artifactId>bucket4j-spring-boot-starter</artifactId>
-				<version>0.0.14-SNAPSHOT</version>
+				<version>0.1.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.vladimir-bukhtoyarov</groupId>
 				<artifactId>bucket4j-core</artifactId>
-				<version>3.0.2</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.vladimir-bukhtoyarov</groupId>
 				<artifactId>bucket4j-jcache</artifactId>
-				<version>3.0.2</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
I've updated the base `pom.xml` to use the latest version of bucket4j-spring-boot-starter. I've also updated Spring-Boot to 2.0.1 because there seems to be an issue with 2.0.0 that was causing Ehcache to through a `ClassNotFoundException` on launch.

Finally, I omitted the version on bucket4j-core and bucket4j-jcache because I think those are inferred (but I can add them back if they are necessary). 