### PR TITLE
fix wrong jcache-provider for Caffeine

### DIFF
--- a/bucket4j-spring-boot-starter-example-caffeine/src/main/resources/application.yml
+++ b/bucket4j-spring-boot-starter-example-caffeine/src/main/resources/application.yml
@@ -8,7 +8,7 @@ management:
 spring:
   cache:
     jcache:
-      provider: org.ehcache.jsr107.EhcacheCachingProvider
+      provider: com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider
     cache-names:
     - buckets
     caffeine:


### PR DESCRIPTION
Use `com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider` as jcache-provider in Caffeine example.